### PR TITLE
process variable in PhantomJS fix

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -9,12 +9,13 @@ var handlers = {};
 var REJECTED = ['REJECTED'];
 var FULFILLED = ['FULFILLED'];
 var PENDING = ['PENDING'];
-/* istanbul ignore else */
-try {
-    if (!process.browser) {
-        // in which we actually take advantage of JS scoping
-        var UNHANDLED = ['UNHANDLED'];
-    }
+
+try { // webpack + PhantomJS throws error on process variable in unit test
+  /* istanbul ignore else */
+  if (!process.browser) {
+      // in which we actually take advantage of JS scoping
+      var UNHANDLED = ['UNHANDLED'];
+  }
 } catch(e) {}
 
 module.exports = Promise;

--- a/lib/index.js
+++ b/lib/index.js
@@ -10,10 +10,12 @@ var REJECTED = ['REJECTED'];
 var FULFILLED = ['FULFILLED'];
 var PENDING = ['PENDING'];
 /* istanbul ignore else */
-if (!process.browser) {
-  // in which we actually take advantage of JS scoping
-  var UNHANDLED = ['UNHANDLED'];
-}
+try {
+    if (!process.browser) {
+        // in which we actually take advantage of JS scoping
+        var UNHANDLED = ['UNHANDLED'];
+    }
+} catch(e) {}
 
 module.exports = Promise;
 


### PR DESCRIPTION
A simple fix, that able to use your module in PhantomJS and avoid this error:

![error screenshow](https://sc-cdn.scaleengine.net/i/ff3b13f176d35b27b1fc5b90100972aa.png)